### PR TITLE
Add ability to have multiple configs in a single request

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,13 +222,8 @@ Each Cloud Scheduler Job requires a JSON payload to tell it which IAM Groups and
 An example JSON payload:
 ```
 {
-    "iam_groups": [
-        "group@test.com",
-        "group2@test.com"
-    ],
-    "sql_instances": [
-        "project:region:instance"
-    ],
+    "iam_groups": ["group@test.com", "group2@test.com"],
+    "sql_instances": ["project:region:instance"],
     "private_ip": false
 }
 ```
@@ -237,23 +232,13 @@ An example of multiple items in JSON payload:
 ```
 [
     {
-        "iam_groups": [
-            "group@test.com",
-            "group2@test.com"
-        ],
-        "sql_instances": [
-            "project:region:instance"
-        ],
+        "iam_groups": ["group@test.com", "group2@test.com"],
+        "sql_instances": ["project:region:instance"],
         "private_ip": false
     },
     {
-        "iam_groups": [
-            "group@test.com",
-            "group3@test.com"
-        ],
-        "sql_instances": [
-            "project:region:instance2"
-        ],
+        "iam_groups": ["group@test.com", "group2@test.com"],
+        "sql_instances": ["project:region:instance"],
         "private_ip": false
     }
 ]

--- a/README.md
+++ b/README.md
@@ -222,11 +222,43 @@ Each Cloud Scheduler Job requires a JSON payload to tell it which IAM Groups and
 An example JSON payload:
 ```
 {
-    "iam_groups": ["group@test.com, "group2@test.com],
-    "sql_instances": ["project:region:instance"],
+    "iam_groups": [
+        "group@test.com",
+        "group2@test.com"
+    ],
+    "sql_instances": [
+        "project:region:instance"
+    ],
     "private_ip": false
 }
 ```
+
+An example of multiple items in JSON payload:
+```
+[
+    {
+        "iam_groups": [
+            "group@test.com",
+            "group2@test.com"
+        ],
+        "sql_instances": [
+            "project:region:instance"
+        ],
+        "private_ip": false
+    },
+    {
+        "iam_groups": [
+            "group@test.com",
+            "group3@test.com"
+        ],
+        "sql_instances": [
+            "project:region:instance2"
+        ],
+        "private_ip": false
+    }
+]
+```
+
 Where:
 - **iam_groups**: List of all IAM Groups to manage IAM database users of.
 - **sql_instances**: List of all Cloud SQL instances to configure.

--- a/app.py
+++ b/app.py
@@ -94,10 +94,14 @@ async def run_groups_authn_wrapper():
     if isinstance(body, list):
         response = []
         for config in body:
-            status, _ = await run_groups_authn(config)
+            try:
+                status, _ = await run_groups_authn(config)
+            except Exception as e:
+                logging.exception(e)
+                status = "An exception occured."
             response.append(status)
         return json.dumps(response), 200
-    elif isinstance(body, dict):
-        return await run_groups_authn(config)
+    if isinstance(body, dict):
+        return await run_groups_authn(body)
     else:
         return "Incorrect input type, expected single json object or list of json objects", 400


### PR DESCRIPTION
* Fix quote in example payload being wrong
* Add wrapper function to parse if input is list or dict and handle
* Returns json object if list is provided with status of each request
* Handle exception when processing mutli to still give response for request
* Moved /run route to new wrapper function