### PR TITLE
feat: add group_roles request param for mapping group role names

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,12 +224,22 @@ An example JSON payload:
 {
     "iam_groups": ["group@test.com", "group2@test.com"],
     "sql_instances": ["project:region:instance"],
+    "group_roles": {
+        "group@test.com": "engineering",
+        "group2@test.com": "accounting"
+    },
     "private_ip": false
 }
 ```
 Where:
 - **iam_groups**: List of all IAM Groups to manage IAM database users of.
 - **sql_instances**: List of all Cloud SQL instances to configure.
+- **group_roles**(optional): Dictionary of IAM group emails as keys and group database
+    role names as values. The group database role name is the database role
+    that will be granted/revoked within GroupSync to each member of the
+    corresponding IAM group. Group role names default to the IAM group email
+    without the domain (everything before the @, i.e "iam-group@test.com"
+    would have a default group role name of "iam-group".
 - **private_ip** (optional): Boolean flag for private or public IP addresses.
 
 **Note:** These are placeholder values and should be replaced with proper IAM groups and Cloud SQL instance connection names.

--- a/iam_groups_authn/sync.py
+++ b/iam_groups_authn/sync.py
@@ -89,13 +89,6 @@ async def groups_sync(
         database_version = await user_service.get_database_version(
             InstanceConnectionName(*instance.split(":"))
         )
-        # get database version of instance and check if supported
-        try:
-            database_version = DatabaseVersion(database_version)
-        except ValueError as e:
-            raise ValueError(
-                f"Unsupported database version for instance `{instance}`. Current supported versions are: {list(DatabaseVersion.__members__.keys())}"
-            ) from e
         # verify that group role for database won't exceed character limit
         verify_group_role_length(iam_groups, group_roles, database_version)
         instance_tasks[instance] = (instance_task, database_version)
@@ -329,7 +322,11 @@ class UserService:
                 "[%s:%s:%s] Database version found: %s"
                 % (project, region, instance, database_version)
             )
-            return database_version
+            return DatabaseVersion(database_version)
+        except ValueError as e:
+            raise ValueError(
+                f"Unsupported database version for instance `{instance}`. Current supported versions are: {list(DatabaseVersion.__members__.keys())}"
+            ) from e
         except Exception as e:
             raise Exception(
                 f"Error: Failed to get the database version for `{instance_connection_name}`. Verify instance connection name and instance details."

--- a/tests/integration/test_group_role_mapping.py
+++ b/tests/integration/test_group_role_mapping.py
@@ -73,7 +73,6 @@ def setup_and_teardown():
         delete_database_user(sql_instance, "short-group-role", credentials)
     except Exception:
         print("------------------------Cleanup Failed!------------------------")
-        raise
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_group_role_mapping.py
+++ b/tests/integration/test_group_role_mapping.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,17 +18,17 @@ from google.auth import default
 from google.auth.transport.requests import Request
 import sqlalchemy
 from aiohttp import ClientSession
-from helpers import delete_database_user, delete_iam_member, add_iam_member
-from iam_groups_authn.iam_admin import get_iam_users
+from helpers import delete_database_user
 from iam_groups_authn.mysql import init_mysql_connection_engine, mysql_username
 from iam_groups_authn.sql_admin import get_instance_users
-from iam_groups_authn.sync import groups_sync, UserService
-import time
+from iam_groups_authn.sync import GroupRoleMaxLengthError, groups_sync, UserService
 
 # load test params from environment
 sql_instance = os.environ["MYSQL_INSTANCE"]
-iam_groups = [os.environ["IAM_GROUPS"]]
+long_iam_group = [os.environ["LONG_GROUP_EMAIL"]]
 test_user = os.environ["TEST_USER"]
+
+os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "service.json"
 
 scopes = [
     "https://www.googleapis.com/auth/admin.directory.group.member",
@@ -61,7 +61,7 @@ def setup_and_teardown():
     """Function for setting up and tearing down test."""
 
     # load in service account credentials for test
-    credentials, project = default(scopes=scopes)
+    credentials, _ = default(scopes=scopes)
 
     # check if credentials are expired
     if not credentials.valid:
@@ -71,31 +71,27 @@ def setup_and_teardown():
     yield credentials
 
     try:
-        # cleanup user from database
-        delete_database_user(sql_instance, mysql_username(test_user), credentials)
-        # re-add member to IAM group
-        add_iam_member(iam_groups[0], test_user, credentials)
+        # cleanup group role from database
+        delete_database_user(sql_instance, "short-group-role", credentials)
     except Exception:
         print("------------------------Cleanup Failed!------------------------")
 
 
 @pytest.mark.asyncio
-async def test_service_mysql(credentials):
-    """Test end-to-end usage of GroupSync service on MySQL instance.
+async def test_long_iam_group_email(credentials):
+    """Test end-to-end use case for mapping a IAM group email that exceeds
+    character limit to a shorter group role.
 
     Test plan:
-        - Verifies test user is not a database user
-        - Run GroupSync
-        - Verifies test user is now a database user
-        - Verifies all IAM members of IAM group have been granted group role
-        - Remove test user from IAM group
-        - Run GroupSync
-        - Verifies test user no longer has group role
+        - Verifies group role is not a database user
+        - Run GroupSync with long IAM email (error)
+        - Run GroupSync with group role mapping (success)
+        - Verify IAM member of group has been granted group role
     """
 
-    # remove database user if they exist
+    # remove group role if it already exists
     try:
-        delete_database_user(sql_instance, mysql_username(test_user), credentials)
+        delete_database_user(sql_instance, "short-group-role", credentials)
     except Exception:
         print("Database user must already have been deleted!")
 
@@ -105,45 +101,25 @@ async def test_service_mysql(credentials):
     # check that test_user is not a database user
     user_service = UserService(client_session, credentials)
     db_users = await get_instance_users(user_service, sql_instance)
-    assert mysql_username(test_user) not in db_users
+    assert mysql_username("short-group-role") not in db_users
 
-    # make sure test_user is member of IAM group
-    try:
-        add_iam_member(iam_groups[0], test_user, credentials)
-        # wait 5 seconds, adding IAM member is slow
-        time.sleep(5)
-    except Exception:
-        print("Member must already belong to IAM Group.")
+    # run groups_sync with email exceeding char limit
+    with pytest.raises(GroupRoleMaxLengthError):
+        await groups_sync(long_iam_group, [sql_instance], credentials, dict(), False)
 
-    # run groups sync
-    await groups_sync(iam_groups, [sql_instance], credentials, dict(), False)
-
-    # check that test_user has been created as database user
+    # run groups_sync with group role mapping
+    group_roles = {long_iam_group[0]: "short-group-role"}
+    await groups_sync(long_iam_group, [sql_instance], credentials, group_roles, False)
+    # check that group role has been created as database user
     db_users = await get_instance_users(user_service, sql_instance)
-    assert mysql_username(test_user) in db_users
+    assert "short-group-role" in db_users
 
     # create database connection to instance
     pool = init_mysql_connection_engine(sql_instance, credentials)
 
-    # check that each iam group member has group role
-    for iam_group in iam_groups:
-        users_with_role = check_role_mysql(pool, mysql_username(iam_group))
-        iam_members = await get_iam_users(user_service, iam_group)
-        for member in iam_members:
-            assert mysql_username(member) in users_with_role
-
-    # remove test_user from IAM group
-    delete_iam_member(iam_groups[0], test_user, credentials)
-
-    # wait 5 seconds, deleting IAM member is slow
-    time.sleep(5)
-
-    # run groups sync
-    await groups_sync(iam_groups, [sql_instance], credentials, dict(), False)
-
-    # verify test_user no longer has group role
-    users_with_role = check_role_mysql(pool, mysql_username(iam_groups[0]))
-    assert mysql_username(test_user) not in users_with_role
+    # check that test user has group role
+    users_with_role = check_role_mysql(pool, "short-group-role")
+    assert mysql_username(test_user) in users_with_role
 
     # close aiohttp client session for graceful exit
     if not client_session.closed:

--- a/tests/integration/test_group_role_mapping.py
+++ b/tests/integration/test_group_role_mapping.py
@@ -28,8 +28,6 @@ sql_instance = os.environ["MYSQL_INSTANCE"]
 long_iam_group = [os.environ["LONG_GROUP_EMAIL"]]
 test_user = os.environ["TEST_USER"]
 
-os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "service.json"
-
 scopes = [
     "https://www.googleapis.com/auth/admin.directory.group.member",
     "https://www.googleapis.com/auth/sqlservice.admin",

--- a/tests/integration/test_postgres_sync.py
+++ b/tests/integration/test_postgres_sync.py
@@ -117,7 +117,7 @@ async def test_service_postgres(credentials):
         print("Member must already belong to IAM Group.")
 
     # run groups sync
-    await groups_sync(iam_groups, [sql_instance], credentials, False)
+    await groups_sync(iam_groups, [sql_instance], credentials, dict(), False)
 
     # check that test_user has been created as database user
     db_users = await get_instance_users(user_service, sql_instance)
@@ -140,7 +140,7 @@ async def test_service_postgres(credentials):
     time.sleep(5)
 
     # run groups sync
-    await groups_sync(iam_groups, [sql_instance], credentials, False)
+    await groups_sync(iam_groups, [sql_instance], credentials, dict(), False)
 
     # verify test_user no longer has group role
     users_with_role = check_role_postgres(pool, mysql_username(iam_groups[0]))

--- a/tests/unit/test_verify_group_role_length.py
+++ b/tests/unit/test_verify_group_role_length.py
@@ -1,0 +1,66 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from iam_groups_authn.sync import verify_group_role_length, GroupRoleMaxLengthError
+from iam_groups_authn.utils import DatabaseVersion
+
+
+@pytest.fixture
+def iam_groups() -> list:
+    return ["super-super-duper-duper-long-email@test.com"]
+
+
+@pytest.fixture
+def database_version() -> DatabaseVersion:
+    return DatabaseVersion.MYSQL_8_0
+
+
+def test_group_email_exceeds_limit(
+    iam_groups: list, database_version: DatabaseVersion
+) -> None:
+    """Test that long IAM group email without group role param set throws error."""
+    group_roles = dict()
+    # test mysql (exceeds 32 chars)
+    with pytest.raises(GroupRoleMaxLengthError):
+        verify_group_role_length(iam_groups, group_roles, database_version)
+    # test postgres (exceed 63 chars)
+    postgres_groups = [
+        "super-super-super-super-super-duper-duper-duper-duper-duper-long-email@test.com"
+    ]
+    database_version = DatabaseVersion.POSTGRES_13
+    with pytest.raises(GroupRoleMaxLengthError):
+        verify_group_role_length(postgres_groups, group_roles, database_version)
+
+
+def test_custom_group_role_mapping(
+    iam_groups: list, database_version: DatabaseVersion
+) -> None:
+    """Test that long IAM group email with group role mapping is successful."""
+    # add short group name to show that only role mappings for long emails are required
+    iam_groups.append("short-group@test.com")
+    group_roles = {"super-super-duper-duper-long-email@test.com": "custom-group-role"}
+    verify_group_role_length(iam_groups, group_roles, database_version)
+
+
+def test_custom_group_role_mapping_exceeds_limit(
+    iam_groups: list, database_version: DatabaseVersion
+) -> None:
+    """Test that group role mapping that exceeds limit throws error."""
+    group_roles = {
+        "super-super-duper-duper-long-email@test.com": "super-super-duper-duper-long-role"
+    }
+    with pytest.raises(GroupRoleMaxLengthError):
+        verify_group_role_length(iam_groups, group_roles, database_version)

--- a/tests/unit/test_verify_group_role_length.py
+++ b/tests/unit/test_verify_group_role_length.py
@@ -35,14 +35,16 @@ def test_group_email_exceeds_limit(
     group_roles = dict()
     # test mysql (exceeds 32 chars)
     with pytest.raises(GroupRoleMaxLengthError):
-        verify_group_role_length(iam_groups, group_roles, database_version)
+        for group in iam_groups:
+            verify_group_role_length(group, group_roles, database_version)
     # test postgres (exceed 63 chars)
     postgres_groups = [
         "super-super-super-super-super-duper-duper-duper-duper-duper-long-email@test.com"
     ]
     database_version = DatabaseVersion.POSTGRES_13
     with pytest.raises(GroupRoleMaxLengthError):
-        verify_group_role_length(postgres_groups, group_roles, database_version)
+        for group in postgres_groups:
+            verify_group_role_length(group, group_roles, database_version)
 
 
 def test_custom_group_role_mapping(
@@ -52,7 +54,8 @@ def test_custom_group_role_mapping(
     # add short group name to show that only role mappings for long emails are required
     iam_groups.append("short-group@test.com")
     group_roles = {"super-super-duper-duper-long-email@test.com": "custom-group-role"}
-    verify_group_role_length(iam_groups, group_roles, database_version)
+    for group in iam_groups:
+        verify_group_role_length(group, group_roles, database_version)
 
 
 def test_custom_group_role_mapping_exceeds_limit(
@@ -63,4 +66,5 @@ def test_custom_group_role_mapping_exceeds_limit(
         "super-super-duper-duper-long-email@test.com": "super-super-duper-duper-long-role"
     }
     with pytest.raises(GroupRoleMaxLengthError):
-        verify_group_role_length(iam_groups, group_roles, database_version)
+        for group in iam_groups:
+            verify_group_role_length(group, group_roles, database_version)


### PR DESCRIPTION
Adding ability to choose/map the group database role that will be created or used by GroupSync for each IAM group.
```
{
    # ... other request args
    "group_roles": {
        "iam-group@test.com": "engineering",
        "iam-group2@test.com": "accounting"
     },
}
```

Closes #66 